### PR TITLE
Just die with an exception instead of locking up ST2 on Windows.

### DIFF
--- a/floobits.py
+++ b/floobits.py
@@ -23,8 +23,9 @@ PY2 = sys.version_info < (3, 0)
 
 
 if PY2 and sublime.platform() == 'windows':
-    sublime.error_message('''Sorry, but the Windows version of Sublime Text 2 lacks Python's select module, so the Floobits plugin won't work.
-Please upgrade to Sublime Text 3. :(''')
+    err_msg = '''Sorry, but the Windows version of Sublime Text 2 lacks Python's select module, so the Floobits plugin won't work.
+Please upgrade to Sublime Text 3. :('''
+    raise(Exception(err_msg))
 elif sublime.platform() == 'osx':
     try:
         p = subprocess.Popen(['/usr/bin/sw_vers', '-productVersion'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
The current code hangs ST2 on startup. This gets rid of the alert, but at least ST2 runs now. People should still see the error in their console.
