### PR TITLE
Fix a bunch of unicode problems in logging.

### DIFF
--- a/floo/common/msg.py
+++ b/floo/common/msg.py
@@ -62,11 +62,12 @@ class MSG(object):
             # TODO: ridiculously inefficient
             try:
                 fd = open(LOG_FILE, 'ab')
+                fmsg = msg
                 try:
-                    msg = msg.encode('utf-8')
+                    fmsg = fmsg.encode('utf-8')
                 except Exception:
                     pass
-                fd.write(msg)
+                fd.write(fmsg)
                 fd.write(b'\n')
                 fd.close()
             except Exception as e:


### PR DESCRIPTION
print converts to ascii sometimes:
https://pythonhosted.org/kitchen/unicode-frustrations.html#frustration-3-inconsistent-treatment-of-output
Some things were getting double encoded.

Issue #168

Try it with https://floobits.com/bjorn/wtfbin
