### PR TITLE
Tweaks OS X version detection so it doesn't choke on 10.10.

### DIFF
--- a/floobits.py
+++ b/floobits.py
@@ -16,7 +16,7 @@ elif sublime.platform() == 'osx':
     try:
         p = subprocess.Popen(['/usr/bin/sw_vers', '-productVersion'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         result = p.communicate()
-        if float(result[0][:4]) < 10.7:
+        if float(result.split('.')[1]) < 7:
             sublime.error_message('''Sorry, but the Floobits plugin doesn\'t work on 10.6 or earlier.
 Please upgrade your operating system if you want to use this plugin. :(''')
     except Exception as e:


### PR DESCRIPTION
The old logic for finding the OS X version was convinced that Yosemite, OS X 10.10, was actually OS X 10.1, whichever cat that was. This infinitesimal change lets Floobits continue running on the new hotness.
